### PR TITLE
Turn DomainMessage into abstract class

### DIFF
--- a/src/Messaging/Command.php
+++ b/src/Messaging/Command.php
@@ -19,7 +19,7 @@ namespace Prooph\Common\Messaging;
  * @package Prooph\Common\Messaging
  * @author Alexander Miertsch <contact@prooph.de>
  */
-class Command extends DomainMessage
+abstract class Command extends DomainMessage
 {
     /**
      * @return string

--- a/src/Messaging/PayloadConstructable.php
+++ b/src/Messaging/PayloadConstructable.php
@@ -6,25 +6,18 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  * 
- * Date: 5/1/15 - 1:44 PM
+ * Date: 7/25/15 - 11:21 PM
  */
+
 namespace Prooph\Common\Messaging;
 
 /**
- * Class DomainEvent
- *
- * This is the base class for domain events.
+ * Interface PayloadConstructable
  *
  * @package Prooph\Common\Messaging
  * @author Alexander Miertsch <kontakt@codeliner.ws>
  */
-abstract class DomainEvent extends DomainMessage
+interface PayloadConstructable 
 {
-    /**
-     * @return string
-     */
-    protected function messageType()
-    {
-        return MessageHeader::TYPE_EVENT;
-    }
-}
+    public function __construct(array $payload);
+} 

--- a/src/Messaging/PayloadTrait.php
+++ b/src/Messaging/PayloadTrait.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * This file is part of the prooph/common.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ * 
+ * Date: 7/25/15 - 11:19 PM
+ */
+
+namespace Prooph\Common\Messaging;
+
+/**
+ * Trait PayloadTrait
+ *
+ * Use this trait together with the PayloadConstructable interface
+ * to use simple message instantiation and default implementations
+ * for DomainMessage::payload() and DomainMessage::setPayload()
+ *
+ * @package Prooph\Common\Messaging
+ * @author Alexander Miertsch <kontakt@codeliner.ws>
+ */
+trait PayloadTrait
+{
+    /**
+     * @var array
+     */
+    protected $payload;
+
+    /**
+     * @param array $payload
+     */
+    public function __construct(array $payload)
+    {
+        $this->init();
+        $this->setPayload($payload);
+    }
+
+    /**
+     * @return array
+     */
+    public function payload()
+    {
+        return $this->payload;
+    }
+
+    /**
+     * @param array $payload
+     */
+    protected function setPayload(array $payload)
+    {
+        $this->payload = $payload;
+    }
+} 

--- a/src/Messaging/Query.php
+++ b/src/Messaging/Query.php
@@ -18,7 +18,7 @@ namespace Prooph\Common\Messaging;
  * @package Prooph\Common\Messaging
  * @author Alexander Miertsch <kontakt@codeliner.ws>
  */
-class Query extends DomainMessage
+abstract class Query extends DomainMessage
 {
     /**
      * Should be either MessageHeader::TYPE_COMMAND or MessageHeader::TYPE_EVENT or MessageHeader::TYPE_QUERY

--- a/tests/Messaging/DomainEventTest.php
+++ b/tests/Messaging/DomainEventTest.php
@@ -12,6 +12,7 @@ namespace ProophTest\Common\Messaging;
 
 use Prooph\Common\Messaging\DomainEvent;
 use Prooph\Common\Messaging\RemoteMessage;
+use ProophTest\Common\Mock\SomethingWasDone;
 use Rhumsaa\Uuid\Uuid;
 
 final class DomainEventTest extends \PHPUnit_Framework_TestCase
@@ -36,7 +37,7 @@ final class DomainEventTest extends \PHPUnit_Framework_TestCase
         $this->uuid = Uuid::uuid4();
         $this->createdAt = new \DateTimeImmutable();
 
-        $this->domainEvent = DomainEvent::fromArray([
+        $this->domainEvent = SomethingWasDone::fromArray([
             'name' => 'TestDomainEvent',
             'uuid' => $this->uuid->toString(),
             'version' => 1,
@@ -101,7 +102,7 @@ final class DomainEventTest extends \PHPUnit_Framework_TestCase
     {
         $commandData = $this->domainEvent->toArray();
 
-        $commandCopy = DomainEvent::fromArray($commandData);
+        $commandCopy = SomethingWasDone::fromArray($commandData);
 
         $this->assertEquals($commandData, $commandCopy->toArray());
     }
@@ -115,7 +116,7 @@ final class DomainEventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(RemoteMessage::class, $remoteMessage);
 
-        $commandCopy = DomainEvent::fromRemoteMessage($remoteMessage);
+        $commandCopy = SomethingWasDone::fromRemoteMessage($remoteMessage);
 
         $this->assertEquals($this->domainEvent->toArray(), $commandCopy->toArray());
     }

--- a/tests/Messaging/QueryTest.php
+++ b/tests/Messaging/QueryTest.php
@@ -13,6 +13,7 @@ namespace ProophTest\Common\Messaging;
 
 use Prooph\Common\Messaging\MessageHeader;
 use Prooph\Common\Messaging\Query;
+use ProophTest\Common\Mock\AskSomething;
 use Rhumsaa\Uuid\Uuid;
 
 final class QueryTest extends \PHPUnit_Framework_TestCase
@@ -22,7 +23,7 @@ final class QueryTest extends \PHPUnit_Framework_TestCase
      */
     function it_has_the_message_type_query()
     {
-        $query = Query::fromArray([
+        $query = AskSomething::fromArray([
             'name' => 'TestQuery',
             'uuid' => Uuid::uuid4()->toString(),
             'version' => 1,

--- a/tests/Mock/AskSomething.php
+++ b/tests/Mock/AskSomething.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * This file is part of the prooph/common.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ * 
+ * Date: 7/25/15 - 11:27 PM
+ */
+namespace ProophTest\Common\Mock;
+
+use Prooph\Common\Messaging\PayloadConstructable;
+use Prooph\Common\Messaging\PayloadTrait;
+use Prooph\Common\Messaging\Query;
+
+final class AskSomething extends Query implements PayloadConstructable
+{
+    use PayloadTrait;
+} 

--- a/tests/Mock/DoSomething.php
+++ b/tests/Mock/DoSomething.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * This file is part of the prooph/common.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ * 
+ * Date: 7/25/15 - 11:13 PM
+ */
+namespace ProophTest\Common\Mock;
+
+
+use Prooph\Common\Messaging\Command;
+use Prooph\Common\Messaging\PayloadConstructable;
+use Prooph\Common\Messaging\PayloadTrait;
+
+final class DoSomething extends Command implements PayloadConstructable
+{
+    use PayloadTrait;
+}

--- a/tests/Mock/SomethingWasDone.php
+++ b/tests/Mock/SomethingWasDone.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * This file is part of the prooph/common.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ * 
+ * Date: 7/25/15 - 11:16 PM
+ */
+namespace ProophTest\Common\Mock;
+
+use Prooph\Common\Messaging\DomainEvent;
+use Prooph\Common\Messaging\PayloadConstructable;
+use Prooph\Common\Messaging\PayloadTrait;
+
+final class SomethingWasDone extends DomainEvent implements PayloadConstructable
+{
+    use PayloadTrait;
+}


### PR DESCRIPTION
- Closes #8
- DomainMessage now longer provides a __construct
- DomainMessage now requires payload() and setPayload() methods
- Added interface and trait to instantiate a message with payload array
- DomainMessage provides immutable methods to change version and metadata