### PR TITLE
Rename name property of domain message to message name

### DIFF
--- a/src/Messaging/DomainMessage.php
+++ b/src/Messaging/DomainMessage.php
@@ -30,7 +30,7 @@ abstract class DomainMessage implements HasMessageName
     /**
      * @var string
      */
-    protected $name;
+    protected $messageName;
 
     /**
      * @var Uuid
@@ -94,9 +94,9 @@ abstract class DomainMessage implements HasMessageName
     public static function fromArray(array $messageData)
     {
         Assertion::keyExists($messageData, 'uuid');
-        Assertion::keyExists($messageData, 'name');
-        Assertion::string($messageData['name'], 'name needs to be string');
-        Assertion::notEmpty($messageData['name'], 'name must not be empty');
+        Assertion::keyExists($messageData, 'message_name');
+        Assertion::string($messageData['message_name'], 'message name needs to be string');
+        Assertion::notEmpty($messageData['message_name'], 'message name must not be empty');
         Assertion::keyExists($messageData, 'version');
         Assertion::integer($messageData['version'], 'version needs to be an integer');
         Assertion::keyExists($messageData, 'payload');
@@ -111,7 +111,7 @@ abstract class DomainMessage implements HasMessageName
         $message = $messageRef->newInstanceWithoutConstructor();
 
         $message->uuid = Uuid::fromString($messageData['uuid']);
-        $message->name = $messageData['name'];
+        $message->messageName = $messageData['message_name'];
         $message->version = $messageData['version'];
         $message->setPayload($messageData['payload']);
         $message->metadata = $messageData['metadata'];
@@ -134,8 +134,8 @@ abstract class DomainMessage implements HasMessageName
             $this->uuid = Uuid::uuid4();
         }
 
-        if ($this->name === null) {
-            $this->name = get_called_class();
+        if ($this->messageName === null) {
+            $this->messageName = get_called_class();
         }
 
         if ($this->createdAt === null) {
@@ -183,7 +183,7 @@ abstract class DomainMessage implements HasMessageName
     public function toArray()
     {
         return [
-            'name' => $this->name,
+            'message_name' => $this->messageName,
             'uuid' => $this->uuid->toString(),
             'version' => $this->version,
             'payload' => $this->payload(),
@@ -197,7 +197,7 @@ abstract class DomainMessage implements HasMessageName
      */
     public function messageName()
     {
-        return $this->name;
+        return $this->messageName;
     }
 
     /**

--- a/src/Messaging/FQCNMessageFactory.php
+++ b/src/Messaging/FQCNMessageFactory.php
@@ -41,7 +41,7 @@ class FQCNMessageFactory implements MessageFactory
             ));
         }
 
-        $messageData['name'] = $messageName;
+        $messageData['message_name'] = $messageName;
 
         return $messageName::fromArray($messageData);
     }

--- a/tests/Messaging/CommandTest.php
+++ b/tests/Messaging/CommandTest.php
@@ -38,7 +38,7 @@ final class CommandTest extends \PHPUnit_Framework_TestCase
         $this->createdAt = new \DateTimeImmutable();
 
         $this->command = DoSomething::fromArray([
-            'name' => 'TestCommand',
+            'message_name' => 'TestCommand',
             'uuid' => $this->uuid->toString(),
             'version' => 1,
             'created_at' => $this->createdAt->format(\DateTime::ISO8601),

--- a/tests/Messaging/DomainEventTest.php
+++ b/tests/Messaging/DomainEventTest.php
@@ -39,7 +39,7 @@ final class DomainEventTest extends \PHPUnit_Framework_TestCase
         $this->createdAt = new \DateTimeImmutable();
 
         $this->domainEvent = SomethingWasDone::fromArray([
-            'name' => 'TestDomainEvent',
+            'message_name' => 'TestDomainEvent',
             'uuid' => $this->uuid->toString(),
             'version' => 1,
             'created_at' => $this->createdAt->format(\DateTime::ISO8601),

--- a/tests/Messaging/QueryTest.php
+++ b/tests/Messaging/QueryTest.php
@@ -23,7 +23,7 @@ final class QueryTest extends \PHPUnit_Framework_TestCase
     function it_has_the_message_type_query()
     {
         $query = AskSomething::fromArray([
-            'name' => 'TestQuery',
+            'message_name' => 'TestQuery',
             'uuid' => Uuid::uuid4()->toString(),
             'version' => 1,
             'created_at' => (new \DateTimeImmutable())->format(\DateTime::ISO8601),


### PR DESCRIPTION
This avoids naming conflicts with custom name properties managed
by implementers of DomainMessage.