### PR TITLE
Add message converter

### DIFF
--- a/src/Messaging/MessageConverter.php
+++ b/src/Messaging/MessageConverter.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * This file is part of the prooph/common.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ * 
+ * Date: 7/26/15 - 3:27 PM
+ */
+
+namespace Prooph\Common\Messaging;
+
+/**
+ * Interface MessageConverter
+ *
+ * A message converter is able to convert a DomainMessage into an array
+ *
+ * @package Prooph\Common\Messaging
+ * @author Alexander Miertsch <kontakt@codeliner.ws>
+ */
+interface MessageConverter 
+{
+    /**
+     * @param DomainMessage $domainMessage
+     * @return array
+     */
+    public function convertToArray(DomainMessage $domainMessage);
+} 

--- a/src/Messaging/NoOpMessageConverter.php
+++ b/src/Messaging/NoOpMessageConverter.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * This file is part of the prooph/common.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ * 
+ * Date: 7/26/15 - 3:30 PM
+ */
+namespace Prooph\Common\Messaging;
+
+/**
+ * Class NoOpMessageConverter
+ *
+ * The NoOpMessageConverter does not perform any conversion logic.
+ * It simply returns DomainMessage::toArray.
+ * The converter acts as a default implementation but allows replacement
+ * with a custom converter using some special logic.
+ *
+ * @package Prooph\Common\Messaging
+ * @author Alexander Miertsch <kontakt@codeliner.ws>
+ */
+final class NoOpMessageConverter implements MessageConverter
+{
+
+    /**
+     * @param DomainMessage $domainMessage
+     * @return array
+     */
+    public function convertToArray(DomainMessage $domainMessage)
+    {
+        return $domainMessage->toArray();
+    }
+}


### PR DESCRIPTION
The message converter should be used by other prooph components instead
of invoking DomainMessage::toArray directly. This allows injection
of custom message converters which may use hydrators or a serializer
to convert a message into an array.