### PR TITLE
Add a message interface to reduce coupling

### DIFF
--- a/src/Messaging/DomainMessage.php
+++ b/src/Messaging/DomainMessage.php
@@ -16,17 +16,13 @@ use Rhumsaa\Uuid\Uuid;
 /**
  * Class DomainMessage
  *
- * Base class for commands and domain events. Both are messages but differ in their intention.
+ * Base class for commands, domain events and queries. All are messages but differ in their intention.
  *
  * @package Prooph\Common\Messaging
  * @author Alexander Miertsch <kontakt@codeliner.ws>
  */
-abstract class DomainMessage implements HasMessageName
+abstract class DomainMessage implements Message
 {
-    const TYPE_COMMAND = 'command';
-    const TYPE_EVENT   = 'event';
-    const TYPE_QUERY   = 'query';
-
     /**
      * @var string
      */
@@ -58,13 +54,6 @@ abstract class DomainMessage implements HasMessageName
      * @var string
      */
     protected $dateTimeFormat = \DateTime::ISO8601;
-
-    /**
-     * Should be either DomainMessage::TYPE_COMMAND or DomainMessage::TYPE_EVENT or DomainMessage::TYPE_QUERY
-     *
-     * @return string
-     */
-    abstract public function messageType();
 
     /**
      * Return message payload as array
@@ -176,7 +165,7 @@ abstract class DomainMessage implements HasMessageName
     }
 
     /**
-     * Returns an array copy of this command
+     * Returns an array copy of this message
      *
      * @return array
      */

--- a/src/Messaging/Message.php
+++ b/src/Messaging/Message.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * This file is part of the prooph/common.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ * 
+ * Date: 8/11/15 - 10:04 PM
+ */
+
+namespace Prooph\Common\Messaging;
+
+use Rhumsaa\Uuid\Uuid;
+
+/**
+ * Interface Message
+ *
+ * @package Prooph\Common\Messaging
+ * @author Alexander Miertsch <kontakt@codeliner.ws>
+ */
+interface Message extends HasMessageName
+{
+    const TYPE_COMMAND = 'command';
+    const TYPE_EVENT   = 'event';
+    const TYPE_QUERY   = 'query';
+
+    /**
+     * Should be one of Message::TYPE_COMMAND, Message::TYPE_EVENT or Message::TYPE_QUERY
+     *
+     * @return string
+     */
+    public function messageType();
+
+    /**
+     * @return Uuid
+     */
+    public function uuid();
+
+    /**
+     * @return int
+     */
+    public function version();
+
+    /**
+     * @return \DateTimeImmutable
+     */
+    public function createdAt();
+
+    /**
+     * @return array
+     */
+    public function metadata();
+
+    /**
+     * Returns a new instance of the message with given version
+     *
+     * @param int $version
+     * @return Message
+     */
+    public function withVersion($version);
+
+    /**
+     * Returns a new instance of the message with given metadata
+     *
+     * Metadata must be given as a hash table containing only scalar values
+     *
+     * @param array $metadata
+     * @return Message
+     */
+    public function withMetadata(array $metadata);
+
+    /**
+     * Returns new instance of message with $key => $value added to metadata
+     *
+     * Given value must have a scalar type.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return Message
+     */
+    public function withAddedMetadata($key, $value);
+}

--- a/src/Messaging/MessageConverter.php
+++ b/src/Messaging/MessageConverter.php
@@ -14,7 +14,7 @@ namespace Prooph\Common\Messaging;
 /**
  * Interface MessageConverter
  *
- * A message converter is able to convert a DomainMessage into an array
+ * A message converter is able to convert a Message into an array
  *
  * @package Prooph\Common\Messaging
  * @author Alexander Miertsch <kontakt@codeliner.ws>
@@ -22,8 +22,10 @@ namespace Prooph\Common\Messaging;
 interface MessageConverter 
 {
     /**
-     * @param DomainMessage $domainMessage
+     *
+     *
+     * @param Message $domainMessage
      * @return array
      */
-    public function convertToArray(DomainMessage $domainMessage);
-} 
+    public function convertToArray(Message $domainMessage);
+}

--- a/src/Messaging/MessageFactory.php
+++ b/src/Messaging/MessageFactory.php
@@ -25,7 +25,7 @@ interface MessageFactory
      *
      * @param string $messageName
      * @param array $messageData
-     * @return DomainMessage
+     * @return Message
      */
     public function createMessageFromArray($messageName, array $messageData);
-} 
+}


### PR DESCRIPTION
This PR adds a Message interface defining the contract for components dealing with messages.
In the future all prooph components will only type hint the interface and will use the already existing [MessageFactory](https://github.com/prooph/common/blob/master/src/Messaging/MessageFactory.php) and/or [MessageConverter](https://github.com/prooph/common/blob/master/src/Messaging/MessageConverter.php) for message conversion.
The interface reduces the public API of a message to a bare minimum. `payload`, `fromArray` and `toArray` are not part of the interface. This forces prooph components to use the listed helpers to convert messages from or to plain PHP arrays and therefor allows for custom message implementations.

However, this PR does not break BC because the public API of DomainMessage is not changed.