### PR TITLE
Force \DateTimeInterface

### DIFF
--- a/src/Messaging/DomainMessage.php
+++ b/src/Messaging/DomainMessage.php
@@ -49,13 +49,6 @@ abstract class DomainMessage implements Message
     protected $metadata = [];
 
     /**
-     * Override this in your message if you want to use another format
-     *
-     * @var string
-     */
-    protected $dateTimeFormat = \DateTime::ISO8601;
-
-    /**
      * Return message payload as array
      *
      * The payload should only contain scalar types and sub arrays.
@@ -82,17 +75,7 @@ abstract class DomainMessage implements Message
      */
     public static function fromArray(array $messageData)
     {
-        Assertion::keyExists($messageData, 'uuid');
-        Assertion::keyExists($messageData, 'message_name');
-        Assertion::string($messageData['message_name'], 'message name needs to be string');
-        Assertion::notEmpty($messageData['message_name'], 'message name must not be empty');
-        Assertion::keyExists($messageData, 'version');
-        Assertion::integer($messageData['version'], 'version needs to be an integer');
-        Assertion::keyExists($messageData, 'payload');
-        Assertion::isArray($messageData['payload'], 'payload needs to be an array');
-        Assertion::keyExists($messageData, 'metadata');
-        Assertion::keyExists($messageData, 'created_at');
-        Assertion::isArray($messageData['metadata'], 'metadata needs to be an array');
+        MessageDataAssertion::assert($messageData);
 
         $messageRef = new \ReflectionClass(get_called_class());
 
@@ -104,11 +87,6 @@ abstract class DomainMessage implements Message
         $message->version = $messageData['version'];
         $message->setPayload($messageData['payload']);
         $message->metadata = $messageData['metadata'];
-
-        if (! $messageData['created_at'] instanceof \DateTimeInterface) {
-            $messageData['created_at'] = \DateTimeImmutable::createFromFormat($message->dateTimeFormat, $messageData['created_at'], new \DateTimeZone('UTC'));
-        }
-
         $message->createdAt = $messageData['created_at'];
 
         return $message;
@@ -177,7 +155,7 @@ abstract class DomainMessage implements Message
             'version' => $this->version,
             'payload' => $this->payload(),
             'metadata' => $this->metadata,
-            'created_at' => $this->createdAt()->format($this->dateTimeFormat)
+            'created_at' => $this->createdAt(),
         ];
     }
 

--- a/src/Messaging/FQCNMessageFactory.php
+++ b/src/Messaging/FQCNMessageFactory.php
@@ -51,11 +51,11 @@ class FQCNMessageFactory implements MessageFactory
         }
 
         if (! isset($messageData['version'])) {
-            $messageData['version'] = 1;
+            $messageData['version'] = 0;
         }
 
         if (! isset($messageData['created_at'])) {
-            $messageData['created_at'] = new \DateTimeImmutable();
+            $messageData['created_at'] = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
         }
 
         if (! isset($messageData['metadata'])) {

--- a/src/Messaging/MessageConverter.php
+++ b/src/Messaging/MessageConverter.php
@@ -30,8 +30,11 @@ interface MessageConverter
      *   'version' => int,
      *   'payload' => array, //MUST only contain sub arrays and/or scalar types, objects, etc. are not allowed!
      *   'metadata' => array, //MUST only contain key/value pairs with values being only scalar types!
-     *   'created_at' => string, //formatted \DateTime
+     *   'created_at' => \DateTimeInterface,
      * ]
+     *
+     * The correct structure and types are asserted by MessageDataAssertion::assert()
+     * so make sure that the returned array of your custom conversion logic passes the assertion.
      *
      * @param Message $domainMessage
      * @return array

--- a/src/Messaging/MessageDataAssertion.php
+++ b/src/Messaging/MessageDataAssertion.php
@@ -77,7 +77,7 @@ final class MessageDataAssertion
     /**
      * @param mixed $payload
      */
-    private function assertSubPayload($payload)
+    private static function assertSubPayload($payload)
     {
         if (is_array($payload)) {
             foreach ($payload as $subPayload) {
@@ -92,7 +92,7 @@ final class MessageDataAssertion
     /**
      * @param array $metadata
      */
-    public function assertMetadata($metadata)
+    public static function assertMetadata($metadata)
     {
         Assertion::isArray($metadata, 'metadata must be an array');
 
@@ -105,7 +105,7 @@ final class MessageDataAssertion
     /**
      * @param \DateTimeInterface $createdAt
      */
-    public function assertCreatedAt($createdAt)
+    public static function assertCreatedAt($createdAt)
     {
         Assertion::isInstanceOf($createdAt, \DateTimeInterface::class, sprintf(
             'created_at must be of type %s. Got %s',

--- a/src/Messaging/MessageDataAssertion.php
+++ b/src/Messaging/MessageDataAssertion.php
@@ -18,7 +18,7 @@ use Assert\Assertion;
  * @package Prooph\Common\Messaging
  * @author Alexander Miertsch <kontakt@codeliner.ws>
  */
-final class MessageDataAssertion 
+final class MessageDataAssertion
 {
     /**
      * @param mixed $messageData

--- a/src/Messaging/MessageDataAssertion.php
+++ b/src/Messaging/MessageDataAssertion.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ * This file is part of the prooph/common.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 8/25/15 - 3:27 PM
+ */
+namespace Prooph\Common\Messaging;
+
+use Assert\Assertion;
+
+/**
+ * Class MessageDataAssertion
+ *
+ * @package Prooph\Common\Messaging
+ * @author Alexander Miertsch <kontakt@codeliner.ws>
+ */
+final class MessageDataAssertion 
+{
+    /**
+     * @param mixed $messageData
+     */
+    public static function assert($messageData)
+    {
+        Assertion::isArray($messageData, 'MessageData must be an array');
+        Assertion::keyExists($messageData, 'message_name', 'MessageData must contain a key message_name');
+        Assertion::keyExists($messageData, 'uuid', 'MessageData must contain a key uuid');
+        Assertion::keyExists($messageData, 'version', 'MessageData must contain a key version');
+        Assertion::keyExists($messageData, 'payload', 'MessageData must contain a key payload');
+        Assertion::keyExists($messageData, 'metadata', 'MessageData must contain a key metadata');
+        Assertion::keyExists($messageData, 'created_at', 'MessageData must contain a key created_at');
+
+        self::assertMessageName($messageData['message_name']);
+        self::assertUuid($messageData['uuid']);
+        self::assertVersion($messageData['version']);
+        self::assertPayload($messageData['payload']);
+        self::assertMetadata($messageData['metadata']);
+        self::assertCreatedAt($messageData['created_at']);
+    }
+
+    /**
+     * @param string $uuid
+     */
+    public static function assertUuid($uuid)
+    {
+        Assertion::uuid($uuid, 'uuid must be a valid UUID string');
+    }
+
+    /**
+     * @param string $messageName
+     */
+    public static function assertMessageName($messageName)
+    {
+        Assertion::minLength($messageName, 3, 'message_name must be string with at least 3 chars length');
+    }
+
+    /**
+     * @param $version
+     */
+    public static function assertVersion($version)
+    {
+        Assertion::min($version, 0, 'version must be an unsigned integer');
+    }
+
+    /**
+     * @param array $payload
+     */
+    public static function assertPayload($payload)
+    {
+        Assertion::isArray($payload, 'payload must be an array');
+        self::assertSubPayload($payload);
+    }
+
+    /**
+     * @param mixed $payload
+     */
+    private function assertSubPayload($payload)
+    {
+        if (is_array($payload)) {
+            foreach ($payload as $subPayload) {
+                self::assertSubPayload($subPayload);
+                return;
+            }
+        }
+
+        Assertion::scalar($payload, 'payload must only contain arrays and scalar values');
+    }
+
+    /**
+     * @param array $metadata
+     */
+    public function assertMetadata($metadata)
+    {
+        Assertion::isArray($metadata, 'metadata must be an array');
+
+        foreach ($metadata as $key => $value) {
+            Assertion::minLength($key, 1, 'A metadata key must be non empty string');
+            Assertion::scalar($value, 'A metadata value must have a scalar type. Got ' . gettype($value) . ' for ' . $key);
+        }
+    }
+
+    /**
+     * @param \DateTimeInterface $createdAt
+     */
+    public function assertCreatedAt($createdAt)
+    {
+        Assertion::isInstanceOf($createdAt, \DateTimeInterface::class, sprintf(
+            'created_at must be of type %s. Got %s',
+            \DateTimeInterface::class,
+            is_object($createdAt)? get_class($createdAt) : gettype($createdAt)
+        ));
+    }
+}

--- a/src/Messaging/MessageFactory.php
+++ b/src/Messaging/MessageFactory.php
@@ -23,13 +23,19 @@ interface MessageFactory
      * Message data MUST contain at least a "payload" key
      * but may also contain "uuid", "message_name", "version", "metadata", and "created_at".
      *
+     * In general the message factory MUST support creating event objects from an array returned by
+     * the corresponding Prooph\Common\Messaging\MessageConverter
+     *
+     * You can use the assertion helper Prooph\Common\Messaging\MessageDataAssertion to assert message data
+     * before processing it.
+     *
      * If one of the optional keys is not part of the message data the factory should use a default instead:
      * For example:
      * uuid = Uuid::uuid4()
      * message_name = $messageName //First parameter passed to the method
      * version = 1
      * metadata = []
-     * created_at = new \DateTimeImmutable('now', new \DateTimeZone('UTC')) //We recommend using UTC
+     * created_at = new \DateTimeImmutable('now', new \DateTimeZone('UTC')) //We treat all dates as UTC
      *
      * @param string $messageName
      * @param array $messageData

--- a/tests/Messaging/CommandTest.php
+++ b/tests/Messaging/CommandTest.php
@@ -35,13 +35,13 @@ final class CommandTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->uuid = Uuid::uuid4();
-        $this->createdAt = new \DateTimeImmutable();
+        $this->createdAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
 
         $this->command = DoSomething::fromArray([
             'message_name' => 'TestCommand',
             'uuid' => $this->uuid->toString(),
             'version' => 1,
-            'created_at' => $this->createdAt->format(\DateTime::ISO8601),
+            'created_at' => $this->createdAt,
             'payload' => ['command' => 'payload'],
             'metadata' => ['command' => 'metadata']
         ]);

--- a/tests/Messaging/DomainEventTest.php
+++ b/tests/Messaging/DomainEventTest.php
@@ -35,13 +35,13 @@ final class DomainEventTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->uuid = Uuid::uuid4();
-        $this->createdAt = new \DateTimeImmutable();
+        $this->createdAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
 
         $this->domainEvent = SomethingWasDone::fromArray([
             'message_name' => 'TestDomainEvent',
             'uuid' => $this->uuid->toString(),
             'version' => 1,
-            'created_at' => $this->createdAt->format(\DateTime::ISO8601),
+            'created_at' => $this->createdAt,
             'payload' => ['event' => 'payload'],
             'metadata' => ['event' => 'metadata']
         ]);

--- a/tests/Messaging/FQCNMessageFactoryTest.php
+++ b/tests/Messaging/FQCNMessageFactoryTest.php
@@ -47,12 +47,12 @@ final class FQCNMessageFactoryTest extends \PHPUnit_Framework_TestCase
             'version' => 2,
             'payload' => ['command' => 'payload'],
             'metadata' => ['command' => 'metadata'],
-            'created_at' => $createdAt->format(\DateTime::ISO8601),
+            'created_at' => $createdAt,
         ]);
 
         $this->assertEquals(DoSomething::class, $command->messageName());
         $this->assertEquals($uuid->toString(), $command->uuid()->toString());
-        $this->assertEquals($createdAt->format(\DateTime::ISO8601), $command->createdAt()->format(\DateTime::ISO8601));
+        $this->assertEquals($createdAt, $command->createdAt());
         $this->assertEquals(2, $command->version());
         $this->assertEquals(['command' => 'payload'], $command->payload());
         $this->assertEquals(['command' => 'metadata'], $command->metadata());
@@ -68,7 +68,7 @@ final class FQCNMessageFactoryTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $this->assertEquals(DoSomething::class, $command->messageName());
-        $this->assertEquals(1, $command->version());
+        $this->assertEquals(0, $command->version());
         $this->assertEquals(['command' => 'payload'], $command->payload());
         $this->assertEquals([], $command->metadata());
     }

--- a/tests/Messaging/MessageDataAssertionTest.php
+++ b/tests/Messaging/MessageDataAssertionTest.php
@@ -1,0 +1,135 @@
+<?php
+/*
+ * This file is part of the prooph/common.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 8/25/15 - 3:50 PM
+ */
+namespace ProophTest\Common\Messaging;
+use Prooph\Common\Messaging\MessageDataAssertion;
+use Prooph\Common\Messaging\NoOpMessageConverter;
+use ProophTest\Common\Mock\DoSomething;
+use Rhumsaa\Uuid\Uuid;
+
+/**
+ * Class MessageDataAssertionTest
+ *
+ * @package ProophTest\Common\Messaging
+ * @author Alexander Miertsch <kontakt@codeliner.ws>
+ */
+final class MessageDataAssertionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    function it_asserts_message_data_returned_by_the_no_op_message_converter()
+    {
+        $testAssertions = new DoSomething(['test' => 'assertions']);
+
+        $messageConverter = new NoOpMessageConverter();
+
+        MessageDataAssertion::assert($messageConverter->convertToArray($testAssertions));
+
+        //No exception thrown means test green
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     * @dataProvider
+     * @dataProvider provideMessageDataWithMissingKey
+     */
+    function it_throws_exception_if_message_data_is_invalid($messageData, $errorMessage)
+    {
+        $this->setExpectedException('\InvalidArgumentException', $errorMessage);
+        MessageDataAssertion::assert($messageData);
+    }
+
+    public function provideMessageDataWithMissingKey()
+    {
+        $uuid = Uuid::uuid4()->toString();
+        $payload = ['foo' => ['bar' => ['baz' => 100]]];
+        $metadata = ['key' => 'value', 'string' => 'scalar'];
+        $createdAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        return [
+            [
+                'message-data',
+                'MessageData must be an array'
+            ],
+            [
+                //#1 uuid is missing
+                ['message_name' => 'test-message', 'version' => 1, 'payload' => $payload, 'metadata' => $metadata, 'created_at' => $createdAt],
+                'MessageData must contain a key uuid'
+            ],
+            [
+                //#2 message_name missing
+                ['uuid' => $uuid, 'version' => 1, 'payload' => $payload, 'metadata' => $metadata, 'created_at' => $createdAt],
+                'MessageData must contain a key message_name'
+            ],
+            [
+                //#3 version missing
+                ['uuid' => $uuid, 'message_name' => 'test-message', 'payload' => $payload, 'metadata' => $metadata, 'created_at' => $createdAt],
+                'MessageData must contain a key version'
+            ],
+            [
+                //#4 payload missing
+                ['uuid' => $uuid, 'message_name' => 'test-message', 'version' => 1, 'metadata' => $metadata, 'created_at' => $createdAt],
+                'MessageData must contain a key payload'
+            ],
+            [
+                //#5 metadata missing
+                ['uuid' => $uuid, 'message_name' => 'test-message', 'version' => 1, 'payload' => $payload, 'created_at' => $createdAt],
+                'MessageData must contain a key metadata'
+            ],
+            [
+                //#6 created at missing
+                ['uuid' => $uuid, 'message_name' => 'test-message', 'version' => 1, 'payload' => $payload, 'metadata' => $metadata],
+                'MessageData must contain a key created_at'
+            ],
+            [
+                //#7 invalid uuid string
+                ['uuid' => 'invalid', 'message_name' => 'test-message', 'version' => 1, 'payload' => $payload, 'metadata' => $metadata, 'created_at' => $createdAt],
+                'uuid must be a valid UUID string'
+            ],
+            [
+                //#8 message name to short
+                ['uuid' => $uuid, 'message_name' => 'te', 'version' => 1, 'payload' => $payload, 'metadata' => $metadata, 'created_at' => $createdAt],
+                'message_name must be string with at least 3 chars length'
+            ],
+            [
+                //#9 version must be an unsigned integer
+                ['uuid' => $uuid, 'message_name' => 'test-message', 'version' => -1, 'payload' => $payload, 'metadata' => $metadata, 'created_at' => $createdAt],
+                'version must be an unsigned integer'
+            ],
+            [
+                //#10 payload must be an array
+                ['uuid' => $uuid, 'message_name' => 'test-message', 'version' => 0, 'payload' => 'string', 'metadata' => $metadata, 'created_at' => $createdAt],
+                'payload must be an array'
+            ],
+            [
+                //#11 payload must not contain objects
+                ['uuid' => $uuid, 'message_name' => 'test-message', 'version' => 0, 'payload' => ['sub' => ['key' => new \stdClass()]], 'metadata' => $metadata, 'created_at' => $createdAt],
+                'payload must only contain arrays and scalar values'
+            ],
+            [
+                //#12 metadata must be an array
+                ['uuid' => $uuid, 'message_name' => 'test-message', 'version' => 0, 'payload' => $payload, 'metadata' => 'string', 'created_at' => $createdAt],
+                'metadata must be an array'
+            ],
+            [
+                //#13 metadata must not contain non scalar values
+                ['uuid' => $uuid, 'message_name' => 'test-message', 'version' => 0, 'payload' => $payload, 'metadata' => ['sub_array' => []], 'created_at' => $createdAt],
+                'A metadata value must have a scalar type. Got array for sub_array'
+            ],
+            [
+                //#14 created_at must be of type \DateTimeInterface
+                ['uuid' => $uuid, 'message_name' => 'test-message', 'version' => 0, 'payload' => $payload, 'metadata' => $metadata, 'created_at' => '2015-08-25 16:30:10'],
+                'created_at must be of type DateTimeInterface. Got string'
+            ],
+        ];
+    }
+}

--- a/tests/Messaging/MessageDataAssertionTest.php
+++ b/tests/Messaging/MessageDataAssertionTest.php
@@ -9,6 +9,7 @@
  * Date: 8/25/15 - 3:50 PM
  */
 namespace ProophTest\Common\Messaging;
+
 use Prooph\Common\Messaging\MessageDataAssertion;
 use Prooph\Common\Messaging\NoOpMessageConverter;
 use ProophTest\Common\Mock\DoSomething;
@@ -25,7 +26,7 @@ final class MessageDataAssertionTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    function it_asserts_message_data_returned_by_the_no_op_message_converter()
+    public function it_asserts_message_data_returned_by_the_no_op_message_converter()
     {
         $testAssertions = new DoSomething(['test' => 'assertions']);
 
@@ -42,7 +43,7 @@ final class MessageDataAssertionTest extends \PHPUnit_Framework_TestCase
      * @dataProvider
      * @dataProvider provideMessageDataWithMissingKey
      */
-    function it_throws_exception_if_message_data_is_invalid($messageData, $errorMessage)
+    public function it_throws_exception_if_message_data_is_invalid($messageData, $errorMessage)
     {
         $this->setExpectedException('\InvalidArgumentException', $errorMessage);
         MessageDataAssertion::assert($messageData);

--- a/tests/Messaging/QueryTest.php
+++ b/tests/Messaging/QueryTest.php
@@ -25,7 +25,7 @@ final class QueryTest extends \PHPUnit_Framework_TestCase
             'message_name' => 'TestQuery',
             'uuid' => Uuid::uuid4()->toString(),
             'version' => 1,
-            'created_at' => (new \DateTimeImmutable())->format(\DateTime::ISO8601),
+            'created_at' => (new \DateTimeImmutable('now', new \DateTimeZone('UTC'))),
             'payload' => ['query' => 'payload'],
             'metadata' => ['query' => 'metadata']
         ]);


### PR DESCRIPTION
As discussed in #36 this PR changes the interface definition of MessageFactory and MessageConverter.

With this changes prooph/common no longer deals with date formats. Now it is up to the event store adapters and message producers to handle date formats correctly (supporting microseconds)

A new MessageDataAssertion helper is available to support adapters and producers with the assertion task.