### PR TITLE
[Suggestion] Abstract use of ramsey/uuid lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "~5.5|~7.0",
-        "ramsey/uuid" : "~2.8",
+        "ramsey/uuid" : "~2.8|~3.0",
         "beberlei/assert": "~2.0"
     },
     "require-dev": {

--- a/src/Messaging/DomainMessage.php
+++ b/src/Messaging/DomainMessage.php
@@ -11,7 +11,7 @@
 namespace Prooph\Common\Messaging;
 
 use Assert\Assertion;
-use Rhumsaa\Uuid\Uuid;
+use Prooph\Common\Uuid;
 
 /**
  * Class DomainMessage
@@ -29,7 +29,7 @@ abstract class DomainMessage implements Message
     protected $messageName;
 
     /**
-     * @var Uuid
+     * @var string
      */
     protected $uuid;
 
@@ -82,7 +82,7 @@ abstract class DomainMessage implements Message
         /** @var $message DomainMessage */
         $message = $messageRef->newInstanceWithoutConstructor();
 
-        $message->uuid = Uuid::fromString($messageData['uuid']);
+        $message->uuid = $messageData['uuid'];
         $message->messageName = $messageData['message_name'];
         $message->version = $messageData['version'];
         $message->setPayload($messageData['payload']);
@@ -98,7 +98,7 @@ abstract class DomainMessage implements Message
     protected function init()
     {
         if ($this->uuid === null) {
-            $this->uuid = Uuid::uuid4();
+            $this->uuid = (new Uuid\Version4Generator())->generate();
         }
 
         if ($this->messageName === null) {
@@ -155,7 +155,7 @@ abstract class DomainMessage implements Message
     {
         return [
             'message_name' => $this->messageName,
-            'uuid' => $this->uuid->toString(),
+            'uuid' => $this->uuid,
             'version' => $this->version,
             'payload' => $this->payload(),
             'metadata' => $this->metadata,

--- a/src/Messaging/FQCNMessageFactory.php
+++ b/src/Messaging/FQCNMessageFactory.php
@@ -10,7 +10,7 @@
  */
 namespace Prooph\Common\Messaging;
 
-use Rhumsaa\Uuid\Uuid;
+use Prooph\Common\Uuid;
 
 /**
  * Class FQCNMessageFactory
@@ -45,7 +45,7 @@ class FQCNMessageFactory implements MessageFactory
         }
 
         if (! isset($messageData['uuid'])) {
-            $messageData['uuid'] = Uuid::uuid4();
+            $messageData['uuid'] = (new Uuid\Version4Generator())->generate();
         }
 
         if (! isset($messageData['version'])) {

--- a/src/Messaging/Message.php
+++ b/src/Messaging/Message.php
@@ -11,8 +11,6 @@
 
 namespace Prooph\Common\Messaging;
 
-use Rhumsaa\Uuid\Uuid;
-
 /**
  * Interface Message
  *
@@ -33,7 +31,7 @@ interface Message extends HasMessageName
     public function messageType();
 
     /**
-     * @return Uuid
+     * @return string
      */
     public function uuid();
 

--- a/src/Messaging/MessageFactory.php
+++ b/src/Messaging/MessageFactory.php
@@ -31,7 +31,7 @@ interface MessageFactory
      *
      * If one of the optional keys is not part of the message data the factory should use a default instead:
      * For example:
-     * uuid = Uuid::uuid4()
+     * uuid = (new \Prooph\Common\Uuid\Version4Generator())->generate()
      * message_name = $messageName //First parameter passed to the method
      * version = 1
      * metadata = []

--- a/src/Uuid/UuidGenerator.php
+++ b/src/Uuid/UuidGenerator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Prooph\Common\Uuid;
+
+interface UuidGenerator
+{
+    /**
+     * @return string
+     */
+    public function generate();
+}

--- a/src/Uuid/Version4Generator.php
+++ b/src/Uuid/Version4Generator.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Prooph\Common\Uuid;
+
+class Version4Generator implements UuidGenerator
+{
+    public function generate()
+    {
+        if (class_exists('Ramsey\Uuid\Uuid')) {
+            return \Ramsey\Uuid\Uuid::uuid4()->toString();
+        } elseif (class_exists('Rhumsaa\Uuid\Uuid')) {
+            return \Rhumsaa\Uuid\Uuid::uuid4()->toString();
+        }
+
+        throw new \LogicException('Generating UUID requires package ramsey/uuid');
+    }
+}

--- a/tests/Messaging/CommandTest.php
+++ b/tests/Messaging/CommandTest.php
@@ -10,10 +10,10 @@
  */
 namespace ProophTest\Common\Messaging;
 
+use ProophTest\Common\Mock\DoSomething;
 use Prooph\Common\Messaging\Command;
 use Prooph\Common\Messaging\DomainMessage;
-use ProophTest\Common\Mock\DoSomething;
-use Rhumsaa\Uuid\Uuid;
+use Prooph\Common\Uuid;
 
 final class CommandTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,18 +28,18 @@ final class CommandTest extends \PHPUnit_Framework_TestCase
     private $createdAt;
 
     /**
-     * @var Uuid
+     * @var string
      */
     private $uuid;
 
     protected function setUp()
     {
-        $this->uuid = Uuid::uuid4();
+        $this->uuid = (new Uuid\Version4Generator())->generate();
         $this->createdAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
 
         $this->command = DoSomething::fromArray([
             'message_name' => 'TestCommand',
-            'uuid' => $this->uuid->toString(),
+            'uuid' => $this->uuid,
             'version' => 1,
             'created_at' => $this->createdAt,
             'payload' => ['command' => 'payload'],
@@ -60,7 +60,7 @@ final class CommandTest extends \PHPUnit_Framework_TestCase
      */
     public function it_has_a_uuid()
     {
-        $this->assertTrue($this->uuid->equals($this->command->uuid()));
+        $this->assertEquals($this->uuid, $this->command->uuid());
     }
 
     /**
@@ -151,7 +151,7 @@ final class CommandTest extends \PHPUnit_Framework_TestCase
         $command = new DoSomething(['command' => 'payload']);
 
         $this->assertEquals(DoSomething::class, $command->messageName());
-        $this->assertInstanceOf(Uuid::class, $command->uuid());
+        $this->assertTrue(is_string($command->uuid()));
         $this->assertEquals(0, $command->version());
         $this->assertEquals((new \DateTimeImmutable)->format('Y-m-d'), $command->createdAt()->format('Y-m-d'));
         $this->assertEquals(['command' => 'payload'], $command->payload());

--- a/tests/Messaging/DomainEventTest.php
+++ b/tests/Messaging/DomainEventTest.php
@@ -12,8 +12,8 @@ namespace ProophTest\Common\Messaging;
 
 use Prooph\Common\Messaging\DomainEvent;
 use Prooph\Common\Messaging\DomainMessage;
+use Prooph\Common\Uuid;
 use ProophTest\Common\Mock\SomethingWasDone;
-use Rhumsaa\Uuid\Uuid;
 
 final class DomainEventTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,18 +28,18 @@ final class DomainEventTest extends \PHPUnit_Framework_TestCase
     private $createdAt;
 
     /**
-     * @var Uuid
+     * @var string
      */
     private $uuid;
 
     protected function setUp()
     {
-        $this->uuid = Uuid::uuid4();
+        $this->uuid = (new Uuid\Version4Generator())->generate();
         $this->createdAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
 
         $this->domainEvent = SomethingWasDone::fromArray([
             'message_name' => 'TestDomainEvent',
-            'uuid' => $this->uuid->toString(),
+            'uuid' => $this->uuid,
             'version' => 1,
             'created_at' => $this->createdAt,
             'payload' => ['event' => 'payload'],
@@ -60,7 +60,7 @@ final class DomainEventTest extends \PHPUnit_Framework_TestCase
      */
     public function it_has_a_uuid()
     {
-        $this->assertTrue($this->uuid->equals($this->domainEvent->uuid()));
+        $this->assertEquals($this->uuid, $this->domainEvent->uuid());
     }
 
     /**

--- a/tests/Messaging/FQCNMessageFactoryTest.php
+++ b/tests/Messaging/FQCNMessageFactoryTest.php
@@ -11,9 +11,9 @@
 namespace ProophTest\Common\Messaging;
 
 use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Uuid;
 use ProophTest\Common\Mock\DoSomething;
 use ProophTest\Common\Mock\InvalidMessage;
-use Rhumsaa\Uuid\Uuid;
 
 /**
  * Class FQCNMessageFactoryTest
@@ -38,12 +38,12 @@ final class FQCNMessageFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function it_creates_a_new_message_from_array_and_fqcn()
     {
-        $uuid = Uuid::uuid4();
+        $uuid = (new Uuid\Version4Generator())->generate();
         $createdAt = new \DateTimeImmutable();
 
 
         $command = $this->messageFactory->createMessageFromArray(DoSomething::class, [
-            'uuid' => $uuid->toString(),
+            'uuid' => $uuid,
             'version' => 2,
             'payload' => ['command' => 'payload'],
             'metadata' => ['command' => 'metadata'],
@@ -51,7 +51,7 @@ final class FQCNMessageFactoryTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $this->assertEquals(DoSomething::class, $command->messageName());
-        $this->assertEquals($uuid->toString(), $command->uuid()->toString());
+        $this->assertEquals($uuid, $command->uuid());
         $this->assertEquals($createdAt, $command->createdAt());
         $this->assertEquals(2, $command->version());
         $this->assertEquals(['command' => 'payload'], $command->payload());

--- a/tests/Messaging/MessageDataAssertionTest.php
+++ b/tests/Messaging/MessageDataAssertionTest.php
@@ -13,7 +13,7 @@ namespace ProophTest\Common\Messaging;
 use Prooph\Common\Messaging\MessageDataAssertion;
 use Prooph\Common\Messaging\NoOpMessageConverter;
 use ProophTest\Common\Mock\DoSomething;
-use Rhumsaa\Uuid\Uuid;
+use Prooph\Common\Uuid;
 
 /**
  * Class MessageDataAssertionTest
@@ -51,7 +51,7 @@ final class MessageDataAssertionTest extends \PHPUnit_Framework_TestCase
 
     public function provideMessageDataWithMissingKey()
     {
-        $uuid = Uuid::uuid4()->toString();
+        $uuid = (new Uuid\Version4Generator())->generate();
         $payload = ['foo' => ['bar' => ['baz' => 100]]];
         $metadata = ['key' => 'value', 'string' => 'scalar'];
         $createdAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));

--- a/tests/Messaging/QueryTest.php
+++ b/tests/Messaging/QueryTest.php
@@ -12,7 +12,7 @@ namespace ProophTest\Common\Messaging;
 
 use Prooph\Common\Messaging\DomainMessage;
 use ProophTest\Common\Mock\AskSomething;
-use Rhumsaa\Uuid\Uuid;
+use Prooph\Common\Uuid;
 
 final class QueryTest extends \PHPUnit_Framework_TestCase
 {
@@ -23,7 +23,7 @@ final class QueryTest extends \PHPUnit_Framework_TestCase
     {
         $query = AskSomething::fromArray([
             'message_name' => 'TestQuery',
-            'uuid' => Uuid::uuid4()->toString(),
+            'uuid' => (new Uuid\Version4Generator())->generate(),
             'version' => 1,
             'created_at' => (new \DateTimeImmutable('now', new \DateTimeZone('UTC'))),
             'payload' => ['query' => 'payload'],


### PR DESCRIPTION
Hello,

I created a Uuid namespace to encapsulate call to Rhumsaa/Ramsey uuid library.
This is needed if to *seamlessly* upgrade to version `~3.0` of the lib (which changed its namespace).
Using a specific interface with a simple `generate()` method allows to decouple from the implementation and let users choose the version of the lib they want to use.

One thing could be debated because it can be considered as a non-BC change: I now handle string instead of `Uuid` object. But it could possible to create a simple `Uuid` class with `toString()` and `equals()` methods.