### PR TITLE
move setPayload call to allow the method to use information from metadata array

### DIFF
--- a/src/Messaging/DomainMessage.php
+++ b/src/Messaging/DomainMessage.php
@@ -85,9 +85,9 @@ abstract class DomainMessage implements Message
         $message->uuid = Uuid::fromString($messageData['uuid']);
         $message->messageName = $messageData['message_name'];
         $message->version = $messageData['version'];
-        $message->setPayload($messageData['payload']);
         $message->metadata = $messageData['metadata'];
         $message->createdAt = $messageData['created_at'];
+        $message->setPayload($messageData['payload']);
 
         return $message;
     }


### PR DESCRIPTION
For example, when the payload is set, we could initialize message value objects like the aggregate id
