### PR TITLE
Upgrade depencency to ramsey/uuid 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "~5.5|~7.0",
-        "ramsey/uuid" : "~2.8",
+        "ramsey/uuid" : "~2.8|~3.0",
         "beberlei/assert": "~2.0"
     },
     "require-dev": {

--- a/src/Messaging/DomainMessage.php
+++ b/src/Messaging/DomainMessage.php
@@ -11,7 +11,7 @@
 namespace Prooph\Common\Messaging;
 
 use Assert\Assertion;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Class DomainMessage

--- a/src/Messaging/FQCNMessageFactory.php
+++ b/src/Messaging/FQCNMessageFactory.php
@@ -10,7 +10,7 @@
  */
 namespace Prooph\Common\Messaging;
 
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Class FQCNMessageFactory

--- a/src/Messaging/Message.php
+++ b/src/Messaging/Message.php
@@ -11,7 +11,7 @@
 
 namespace Prooph\Common\Messaging;
 
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Interface Message

--- a/tests/Messaging/CommandTest.php
+++ b/tests/Messaging/CommandTest.php
@@ -13,7 +13,7 @@ namespace ProophTest\Common\Messaging;
 use Prooph\Common\Messaging\Command;
 use Prooph\Common\Messaging\DomainMessage;
 use ProophTest\Common\Mock\DoSomething;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 final class CommandTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Messaging/DomainEventTest.php
+++ b/tests/Messaging/DomainEventTest.php
@@ -13,7 +13,7 @@ namespace ProophTest\Common\Messaging;
 use Prooph\Common\Messaging\DomainEvent;
 use Prooph\Common\Messaging\DomainMessage;
 use ProophTest\Common\Mock\SomethingWasDone;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 final class DomainEventTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Messaging/FQCNMessageFactoryTest.php
+++ b/tests/Messaging/FQCNMessageFactoryTest.php
@@ -13,7 +13,7 @@ namespace ProophTest\Common\Messaging;
 use Prooph\Common\Messaging\FQCNMessageFactory;
 use ProophTest\Common\Mock\DoSomething;
 use ProophTest\Common\Mock\InvalidMessage;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Class FQCNMessageFactoryTest

--- a/tests/Messaging/MessageDataAssertionTest.php
+++ b/tests/Messaging/MessageDataAssertionTest.php
@@ -13,7 +13,7 @@ namespace ProophTest\Common\Messaging;
 use Prooph\Common\Messaging\MessageDataAssertion;
 use Prooph\Common\Messaging\NoOpMessageConverter;
 use ProophTest\Common\Mock\DoSomething;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Class MessageDataAssertionTest

--- a/tests/Messaging/QueryTest.php
+++ b/tests/Messaging/QueryTest.php
@@ -12,7 +12,7 @@ namespace ProophTest\Common\Messaging;
 
 use Prooph\Common\Messaging\DomainMessage;
 use ProophTest\Common\Mock\AskSomething;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 final class QueryTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
This change bases the existing code on the 3.x version of ramsey/uuid (previously called rhumsaa/uuid) in order to avoid conflicts with third-party libraries which require version 3.0 or higher.