### PR TITLE
[MessageDataAssertion] Changed Assertion type to assertSubPayload

### DIFF
--- a/src/Messaging/MessageDataAssertion.php
+++ b/src/Messaging/MessageDataAssertion.php
@@ -67,7 +67,7 @@ final class MessageDataAssertion
             return;
         }
 
-        Assertion::nullOrscalar($payload, 'payload must only contain arrays and scalar values');
+        Assertion::nullOrNotEmpty($payload, 'payload must be null or notEmpty');
     }
 
     public static function assertMetadata($metadata): void


### PR DESCRIPTION
Changed Assertion type to assertSubPayload method to nullOrEmpty because nullOrScalar caused trouble when payload was a Class (ValueObject).

There are no tests for this assertion so I am not sure if it breaking something else.
* I don't know if notEmpty is still the right approach, maybe you should consider to remove the assertSubPayload check or explain why is needed.