### PR TITLE
Fix DomainMessage metadata bottleneck

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-Copyright (c) 2014-2017, prooph software GmbH
-Copyright (c) 2015-2017, Sascha-Oliver Prolic
+Copyright (c) 2014-2018, prooph software GmbH
+Copyright (c) 2015-2018, Sascha-Oliver Prolic
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/Event/ActionEvent.php
+++ b/src/Event/ActionEvent.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Event/ActionEventEmitter.php
+++ b/src/Event/ActionEventEmitter.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Event/ActionEventListenerAggregate.php
+++ b/src/Event/ActionEventListenerAggregate.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Event/DefaultActionEvent.php
+++ b/src/Event/DefaultActionEvent.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Event/DefaultListenerHandler.php
+++ b/src/Event/DefaultListenerHandler.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Event/DetachAggregateHandlers.php
+++ b/src/Event/DetachAggregateHandlers.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Event/ListenerHandler.php
+++ b/src/Event/ListenerHandler.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Event/ProophActionEventEmitter.php
+++ b/src/Event/ProophActionEventEmitter.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Messaging/Command.php
+++ b/src/Messaging/Command.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Messaging/DomainEvent.php
+++ b/src/Messaging/DomainEvent.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Messaging/DomainMessage.php
+++ b/src/Messaging/DomainMessage.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Messaging/DomainMessage.php
+++ b/src/Messaging/DomainMessage.php
@@ -111,11 +111,11 @@ abstract class DomainMessage implements Message
 
     public function withMetadata(array $metadata): Message
     {
-        $messageData = $this->toArray();
+        $message = clone $this;
 
-        $messageData['metadata'] = $metadata;
+        $message->metadata = $metadata;
 
-        return static::fromArray($messageData);
+        return $message;
     }
 
     /**
@@ -127,10 +127,10 @@ abstract class DomainMessage implements Message
     {
         Assertion::notEmpty($key, 'Invalid key');
 
-        $messageData = $this->toArray();
+        $message = clone $this;
 
-        $messageData['metadata'][$key] = $value;
+        $message->metadata[$key] = $value;
 
-        return static::fromArray($messageData);
+        return $message;
     }
 }

--- a/src/Messaging/FQCNMessageFactory.php
+++ b/src/Messaging/FQCNMessageFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Messaging/HasMessageName.php
+++ b/src/Messaging/HasMessageName.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Messaging/Message.php
+++ b/src/Messaging/Message.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Messaging/MessageConverter.php
+++ b/src/Messaging/MessageConverter.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Messaging/MessageDataAssertion.php
+++ b/src/Messaging/MessageDataAssertion.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Messaging/MessageFactory.php
+++ b/src/Messaging/MessageFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Messaging/NoOpMessageConverter.php
+++ b/src/Messaging/NoOpMessageConverter.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Messaging/PayloadConstructable.php
+++ b/src/Messaging/PayloadConstructable.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Messaging/PayloadTrait.php
+++ b/src/Messaging/PayloadTrait.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Messaging/Query.php
+++ b/src/Messaging/Query.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Event/DefaultActionEventTest.php
+++ b/tests/Event/DefaultActionEventTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Event/ProophActionEventEmitterTest.php
+++ b/tests/Event/ProophActionEventEmitterTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Messaging/CommandTest.php
+++ b/tests/Messaging/CommandTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Messaging/DomainEventTest.php
+++ b/tests/Messaging/DomainEventTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Messaging/FQCNMessageFactoryTest.php
+++ b/tests/Messaging/FQCNMessageFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Messaging/MessageDataAssertionTest.php
+++ b/tests/Messaging/MessageDataAssertionTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Messaging/NoOpMessageConverterTest.php
+++ b/tests/Messaging/NoOpMessageConverterTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Messaging/QueryTest.php
+++ b/tests/Messaging/QueryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/ActionEventListenerMock.php
+++ b/tests/Mock/ActionEventListenerMock.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/ActionListenerAggregateMock.php
+++ b/tests/Mock/ActionListenerAggregateMock.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/AskSomething.php
+++ b/tests/Mock/AskSomething.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/DoSomething.php
+++ b/tests/Mock/DoSomething.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/InvalidMessage.php
+++ b/tests/Mock/InvalidMessage.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Mock/SomethingWasDone.php
+++ b/tests/Mock/SomethingWasDone.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/common.
- * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
It turns out that adding metadata to a command or query is a serious bottleneck in our application because of the `toArray` and `fromArray` transformations used in those methods. In our case it's about 10% of the total time the server needs to respond to a http request. The reason why it is a bottleneck is because the messages contain Ramsey\Uuid objects which are slow to convert to string and back. So I need to prevent this from happening.

I've fixed it by changing the fromArray / toArray logic to simple PHP clone. Now this of course can be considered a BC break since the clone is no longer deep after this. I'm not exactly sure if this is a problem (it's not for me) so you need to consider the possible impacts before merging this. I'm fine with changing the logic on my side in case you don't want this change. Anyway I think you should know about this bottleneck and maybe consider some other changes to solve it.
