### PR TITLE
Allow beberlei/assert v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.1.0",
         "ramsey/uuid" : "^3.6.0",
-        "beberlei/assert": "^2.7.1"
+        "beberlei/assert": "^2.7.1 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",


### PR DESCRIPTION
Added beberlei/assert ^3.0 to allowed versions.
No additional changes needed since it did not introduce any BC breaks apart for dropping old php versions support: https://github.com/beberlei/assert/compare/v2.9.6...v3.0.0