### PR TITLE
Add return annotations

### DIFF
--- a/src/Messaging/DomainMessage.php
+++ b/src/Messaging/DomainMessage.php
@@ -109,6 +109,9 @@ abstract class DomainMessage implements Message
         return $this->messageName;
     }
 
+    /**
+     * @return static
+     */
     public function withMetadata(array $metadata): Message
     {
         $message = clone $this;
@@ -122,6 +125,8 @@ abstract class DomainMessage implements Message
      * Returns new instance of message with $key => $value added to metadata
      *
      * Given value must have a scalar type.
+     *
+     * @return static
      */
     public function withAddedMetadata(string $key, $value): Message
     {


### PR DESCRIPTION
This way PHPStorm and PHPStan will understand that `$message->withAddedMetadata()` is an instance of the same class as `$message`.