### PR TITLE
wrong uuid version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4 || ^8.0",
-        "ramsey/uuid": "4.2.1 || ^4.3",
+        "ramsey/uuid": "4.1.2 || ^4.3",
         "beberlei/assert": "^2.7.1 || ^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
I used the wrong uuid version. 4.1.2 runs only on ^7.2 || ~8.0.0 which is the constrained we need for dependant packages...

an install with --prefer-lowest would still get a working version no matter which php version is used.

